### PR TITLE
Add minimal Farsi UI with track page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once running, visit `http://localhost:3000/api/health` to check the server statu
 
 ## Frontend
 
-The frontend lives under `frontend/pages`. It loads a simple chatbot widget.
+The frontend lives under `frontend/pages` and uses TailwindCSS. A new example page `track/tipax.html` demonstrates the minimal Persian UI with the Vazirmatn font and chatbot widget.
 
 ### Run a Development Server
 

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -4,20 +4,56 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PORSIT</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Vazirmatn', 'Inter', 'sans-serif']
+          },
+          colors: {
+            basebg: '#F9FAFB',
+            cardbg: '#FFFFFF',
+            primarytxt: '#111827',
+            secondarytxt: '#6B7280',
+            blue: '#3B82F6',
+            green: '#10B981',
+            red: '#EF4444',
+            purple: '#8B5CF6',
+            orange: '#F97316'
+          }
+        }
+      }
+    }
+  </script>
 </head>
-<body class="bg-gray-50 text-gray-900">
-  <div class="container mx-auto py-8 grid grid-cols-1 md:grid-cols-3 gap-6">
-    <div class="col-span-1 md:col-span-2">
-      <h1 class="text-3xl font-bold mb-4">پُرسیت</h1>
-      <p class="text-sm text-gray-600">پلتفرم حمل و نقل و دستیار هوشمند</p>
+<body class="font-sans text-sm bg-basebg text-primarytxt leading-relaxed">
+  <div class="container mx-auto py-8 grid grid-cols-1 md:grid-cols-3 gap-8">
+    <div class="col-span-1 md:col-span-2 space-y-4">
+      <h1 class="text-3xl font-bold">پُرسیت</h1>
+      <p class="text-secondarytxt text-sm">پلتفرم حمل و نقل و دستیار هوشمند</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <a href="track/tipax.html" class="bg-cardbg rounded-xl shadow-sm p-4 flex items-center gap-2 hover:shadow-md">
+          <span class="text-blue-600">پیگیری مرسوله</span>
+        </a>
+        <a href="#" class="bg-cardbg rounded-xl shadow-sm p-4 flex items-center gap-2 hover:shadow-md">
+          <span class="text-blue-600">استعلام هزینه</span>
+        </a>
+        <a href="#" class="bg-cardbg rounded-xl shadow-sm p-4 flex items-center gap-2 hover:shadow-md">
+          <span class="text-blue-600">تحویل سریع</span>
+        </a>
+      </div>
     </div>
-    <aside class="sticky top-0 w-60">
+    <aside class="sticky top-4 w-60">
       <nav>
-        <ul class="space-y-2">
-          <li><a href="#" class="text-blue-500">پیگیری مرسوله</a></li>
-          <li><a href="#" class="text-blue-500">استعلام هزینه</a></li>
-          <li><a href="#" class="text-blue-500">تحویل سریع</a></li>
+        <ul class="space-y-2 text-sm">
+          <li><a href="track/tipax.html" class="block py-2 px-3 rounded-lg hover:bg-blue-50">پیگیری مرسوله</a></li>
+          <li><a href="#" class="block py-2 px-3 rounded-lg hover:bg-blue-50">استعلام هزینه</a></li>
+          <li><a href="#" class="block py-2 px-3 rounded-lg hover:bg-blue-50">تحویل سریع</a></li>
         </ul>
       </nav>
     </aside>

--- a/frontend/pages/track/tipax.html
+++ b/frontend/pages/track/tipax.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>پیگیری مرسوله تیپاکس</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Vazirmatn', 'Inter', 'sans-serif']
+          },
+          colors: {
+            basebg: '#F9FAFB',
+            cardbg: '#FFFFFF',
+            primarytxt: '#111827',
+            secondarytxt: '#6B7280',
+            blue: '#3B82F6',
+            green: '#10B981',
+            red: '#EF4444',
+            purple: '#8B5CF6',
+            orange: '#F97316'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans text-sm bg-basebg text-primarytxt leading-relaxed">
+  <header class="px-6 py-4 bg-cardbg shadow-sm">
+    <nav class="container mx-auto flex justify-between">
+      <div class="text-lg font-bold">پُرسیت</div>
+      <a href="/" class="text-blue-600">خانه</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-8 grid grid-cols-1 md:grid-cols-3 gap-8">
+    <section class="md:col-span-2 space-y-4">
+      <h1 class="text-2xl font-bold">پیگیری مرسوله تیپاکس</h1>
+      <p class="text-secondarytxt text-sm">برای مشاهده وضعیت بسته خود، کد رهگیری را وارد کنید.</p>
+      <div class="bg-cardbg rounded-xl shadow-sm p-6 flex flex-col gap-4">
+        <input id="trackCode" type="text" placeholder="کد رهگیری" class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        <button id="trackBtn" class="bg-blue-600 text-white rounded-lg px-4 py-2 hover:bg-blue-700">پیگیری</button>
+        <pre id="result" class="text-sm text-green-600"></pre>
+      </div>
+    </section>
+  </main>
+
+  <script type="module">
+    import { initChatbot } from "../../chatbot-widget/widget.js";
+    initChatbot();
+    document.getElementById('trackBtn').onclick = () => {
+      const code = document.getElementById('trackCode').value.trim();
+      const result = document.getElementById('result');
+      if (code) {
+        result.textContent = `وضعیت مرسوله ${code} در حال بررسی است...`;
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- apply custom Tailwind config with Vazirmatn font and new color palette
- redesign index layout with card links
- add `track/tipax.html` example page in Farsi
- update README with new frontend info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884c72072988329abd4b9ff7ca734d9